### PR TITLE
Add basic FastAPI VIN decoding service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # cde-api
+
+Simple FastAPI service for decoding VINs and serving associated images.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Endpoints
+
+- `GET /decode/{vin}` - Decode a VIN into its component parts.
+- `GET /decode/{vin}/image` - Retrieve an image for the VIN (if available).
+
+A sample VIN `1M8GDM9AXKP042788` is included with an in-memory placeholder image.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# fastapi app package

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,34 @@
+import base64
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import Response
+
+from .vin_decoder import decode_vin
+
+app = FastAPI(title="VIN Decoder API")
+
+# Mapping of sample VINs to base64-encoded image bytes
+SAMPLE_PNG_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+)
+IMAGES = {
+    "1M8GDM9AXKP042788": base64.b64decode(SAMPLE_PNG_BASE64),
+}
+
+
+@app.get("/decode/{vin}")
+def decode(vin: str):
+    """Return decoded data for a VIN."""
+    try:
+        return decode_vin(vin.upper())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@app.get("/decode/{vin}/image")
+def image(vin: str):
+    """Return an image associated with the VIN."""
+    data = IMAGES.get(vin.upper())
+    if not data:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return Response(content=data, media_type="image/png")

--- a/app/vin_decoder.py
+++ b/app/vin_decoder.py
@@ -1,0 +1,20 @@
+"""Simple VIN decoder."""
+
+from typing import Dict
+
+
+def decode_vin(vin: str) -> Dict[str, str]:
+    """Decode a VIN into its component parts.
+
+    The function performs minimal validation and splits the VIN into
+    WMI (first 3 characters), VDS (next 6 characters), and VIS (last 8 characters).
+    """
+    if len(vin) != 17:
+        raise ValueError("VIN must be 17 characters long")
+
+    return {
+        "vin": vin,
+        "wmi": vin[:3],
+        "vds": vin[3:9],
+        "vis": vin[9:],
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_decode_success():
+    vin = "1M8GDM9AXKP042788"
+    response = client.get(f"/decode/{vin}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["vin"] == vin
+    assert data["wmi"] == vin[:3]
+    assert data["vds"] == vin[3:9]
+    assert data["vis"] == vin[9:]
+
+
+def test_decode_invalid_length():
+    response = client.get("/decode/123")
+    assert response.status_code == 400
+
+
+def test_image_endpoint():
+    vin = "1M8GDM9AXKP042788"
+    response = client.get(f"/decode/{vin}/image")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+
+
+def test_image_not_found():
+    response = client.get("/decode/INVALIDVIN000000/image")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- scaffold FastAPI app for VIN decoding and image retrieval
- replace sample image file with in-memory placeholder
- add tests and documentation

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a3af8b01c4832db42f0cc37076e325